### PR TITLE
feat: Load participants from Local Storage

### DIFF
--- a/src/Timer/Counter.js
+++ b/src/Timer/Counter.js
@@ -17,7 +17,10 @@ const Count = styled.span`
   color: #FBBC05;
 `
 
-const Controls = styled.div``
+const Controls = styled.div`
+  display: flex;
+  gap: 5px;
+`
 
 const Status = styled.span`
   color: white;
@@ -44,9 +47,11 @@ const Counter = ({ expiryTimestamp, onExpire }) => {
 
   return (
     <Container>
-      <Count><span>{minutes}</span>:<span>{seconds}</span></Count>
-      <Status>{isRunning ? 'Contando...' : 'Parado.'}</Status>
-      <Controls style={{ textAlign: 'center' }}>
+      <Count>
+        <span>{formatDigits(minutes)}</span>:<span>{formatDigits(seconds)}</span>
+      </Count>
+      <Status>{isRunning ? "Contando..." : "Parado."}</Status>
+      <Controls style={{ textAlign: "center" }}>
         <Button onClick={onExpire}>Proximo</Button>
         <Button onClick={start}>Iniciar</Button>
         <Button onClick={pause}>Pausar</Button>
@@ -54,7 +59,10 @@ const Counter = ({ expiryTimestamp, onExpire }) => {
         <Button onClick={_restart}>Reiniciar</Button>
       </Controls>
     </Container>
-  )
+  );
 }
 
 export default Counter
+
+const formatDigits = (n) =>
+  n.toLocaleString("pt-BR", { minimumIntegerDigits: 2 });

--- a/src/Timer/index.js
+++ b/src/Timer/index.js
@@ -2,7 +2,6 @@ import { useState } from 'react'
 import styled from 'styled-components'
 import Counter from './Counter'
 import Participants from './Participants'
-import data from '../participants.json'
 
 const Container = styled.div`
   display: flex;
@@ -10,7 +9,7 @@ const Container = styled.div`
   height: 100%;
 `
 
-const Timer = () => {
+const Timer = ({ participants: data }) => {
   const randomizedData = data.sort(() => Math.random() - 0.5)
   const [curr, setCurr] = useState({ pilot: randomizedData[0], copilot: randomizedData[1] })
   const [participants, setParticipants] = useState(randomizedData.slice(2, randomizedData.length))
@@ -20,7 +19,6 @@ const Timer = () => {
 
   const getNext = () => {
     const nextCopilot = participants.shift()
-    
     setParticipants([...participants, curr.pilot])
     setCurr({ pilot: curr.copilot, copilot: nextCopilot })
   }

--- a/src/TimerManager.js
+++ b/src/TimerManager.js
@@ -1,0 +1,101 @@
+import { useState } from "react";
+import styled from "styled-components";
+import Button from "./components/Button";
+import useLocalStorage from "./hooks/useLocalStorage";
+import Timer from "./Timer";
+
+function TimerManager() {
+  const [ready, setReady] = useState(false);
+  const [participants, setParticipants] = useLocalStorage("participants", [
+    "",
+    "",
+    "",
+  ]);
+
+  if (ready) {
+    return <Timer participants={participants.filter(Boolean)} />;
+  }
+
+  return (
+    <Container>
+      <h1>Participantes</h1>
+
+      {participants.map((partipant, index) => {
+        return (
+          <Row key={`participant_${index}`}>
+            <Input
+              placeholder="Nome"
+              value={partipant}
+              onChange={(event) => {
+                const { value } = event.target;
+
+                setParticipants((arr) => {
+                  arr[index] = value;
+                  return [...arr];
+                });
+              }}
+            />
+            <Button
+              color="#ef8354"
+              onClick={() => {
+                setParticipants((arr) => arr.filter((_, x) => x !== index));
+              }}
+            >
+              Remover
+            </Button>
+          </Row>
+        );
+      })}
+      <Actions>
+        <Button
+          color="#00c49a"
+          onClick={() => {
+            setParticipants((arr) => [...arr, ""]);
+          }}
+        >
+          Adicionar
+        </Button>
+
+        <Button
+          color="#4381c1"
+          onClick={() => {
+            setReady(true);
+          }}
+        >
+          Pronto
+        </Button>
+      </Actions>
+    </Container>
+  );
+}
+
+export default TimerManager;
+
+const Container = styled.div`
+  margin: 24px auto;
+  width: 720px;
+
+  h1 {
+    font-size: 24px;
+    font-weight: bold;
+    margin-bottom: 12px;
+  }
+`;
+
+const Row = styled.div`
+  display: flex;
+  align-items: center;
+  margin-bottom: 12px;
+  gap: 5px;
+`;
+
+const Input = styled.input`
+  flex: 1;
+  padding: 10px 15px;
+`;
+
+const Actions = styled.div`
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+`;

--- a/src/components/Button/index.js
+++ b/src/components/Button/index.js
@@ -1,10 +1,9 @@
 import styled from 'styled-components'
 
 const Button = styled.button`
-  background: #34A853;
+  background: ${props => props.color || '#34A853'};
   padding: 10px 15px;
   border: none;
-  margin: 0 5px;
   color: white;
   font-weight: bold;
   font-size: 16px;

--- a/src/hooks/useLocalStorage.js
+++ b/src/hooks/useLocalStorage.js
@@ -1,0 +1,23 @@
+import { useEffect, useState } from "react";
+
+function useLocalStorage(key, initialState) {
+  const [state, setState] = useState(() => {
+    try {
+      const storedState = localStorage.getItem(`dojo-timer.${key}`);
+      if (!storedState) {
+        return initialState;
+      }
+      return JSON.parse(storedState);
+    } catch {
+      return initialState;
+    }
+  });
+
+  useEffect(() => {
+    localStorage.setItem(`dojo-timer.${key}`, JSON.stringify(state));
+  }, [key, state]);
+
+  return [state, setState];
+}
+
+export default useLocalStorage;

--- a/src/index.js
+++ b/src/index.js
@@ -1,15 +1,15 @@
 import React from 'react';
 import ReactDOM from 'react-dom/client';
-import Timer from './Timer';
 import reportWebVitals from './reportWebVitals';
 import './assets/css/reset.css';
 import GlobalStyle from './GlobalStyle';
+import TimerManager from './TimerManager';
 
 const root = ReactDOM.createRoot(document.getElementById('root'));
 root.render(
   <React.StrictMode>
     <GlobalStyle />
-    <Timer />
+    <TimerManager />
   </React.StrictMode>
 );
 


### PR DESCRIPTION
![timer-updates](https://user-images.githubusercontent.com/8146112/207761554-4b73d599-b5b5-4e43-a853-a17159b0765e.gif)

This PR adds a "setup" screen where we can update the participants. The participants will be stored in the LocalStorage, so we don't need to re-enter them every time.

Also, this PR formats the timer to "04:01" instead of "4:1".